### PR TITLE
Fix: Load .env from plugin directory (not just cwd)

### DIFF
--- a/.opencode/plugin/telegram-remote.js
+++ b/.opencode/plugin/telegram-remote.js
@@ -111,8 +111,13 @@ function createBotManager(bot, sessionTitleService) {
 }
 
 // src/config.ts
-import { resolve } from "path";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 import { config as loadEnv } from "dotenv";
+var __filename = fileURLToPath(import.meta.url);
+var __dirname = dirname(__filename);
+loadEnv({ path: resolve(__dirname, "..", "..", ".env") });
+loadEnv({ path: resolve(__dirname, "..", ".env") });
 loadEnv({ path: resolve(process.cwd(), ".env") });
 function parseAllowedUserIds(value) {
   if (!value || value.trim() === "") {
@@ -161,23 +166,14 @@ async function handleSessionStatus(event, context) {
   const statusType = event?.properties?.status?.type;
   if (statusType) {
     if (statusType === "idle") {
-      console.log(`[TelegramRemote] Session is idle. Sending finished notification.`);
       try {
         const sessionId = event?.properties?.info?.id ?? event?.properties?.sessionID ?? event?.properties?.id;
-        console.log("[TelegramRemote] Extracted sessionId for idle event:", sessionId);
-        console.log("[TelegramRemote] Event structure:", JSON.stringify(event?.properties, null, 2));
         let message = "Agent has finished.";
         if (sessionId && context.sessionTitleService) {
           const title = context.sessionTitleService.getSessionTitle(sessionId);
-          console.log("[TelegramRemote] Retrieved title from service:", title);
           if (title) {
             message = `Agent has finished: ${title}`;
           }
-        } else {
-          console.log("[TelegramRemote] SessionId or sessionTitleService missing:", {
-            hasSessionId: !!sessionId,
-            hasService: !!context.sessionTitleService
-          });
         }
         await context.bot.sendMessage(message);
       } catch (error) {
@@ -200,7 +196,6 @@ async function handleSessionUpdated(event, context) {
 
 // src/events/question-asked.ts
 async function handleQuestionAsked(event, context) {
-  console.log("[TelegramRemote] handleQuestionAsked called with event:", JSON.stringify(event, null, 2));
   const sessionID = event?.properties?.sessionID;
   const questions = event?.properties?.questions;
   if (sessionID && questions && Array.isArray(questions) && questions.length > 0 && context.bot) {
@@ -214,7 +209,6 @@ async function handleQuestionAsked(event, context) {
 
 \u2753 Questions:
 ${questionTexts}`;
-    console.log(`[TelegramRemote] Sending questions for session ${sessionID}`);
     try {
       await context.bot.sendMessage(message);
     } catch (error) {

--- a/plugin/dist/telegram-remote.js
+++ b/plugin/dist/telegram-remote.js
@@ -111,8 +111,13 @@ function createBotManager(bot, sessionTitleService) {
 }
 
 // src/config.ts
-import { resolve } from "path";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 import { config as loadEnv } from "dotenv";
+var __filename = fileURLToPath(import.meta.url);
+var __dirname = dirname(__filename);
+loadEnv({ path: resolve(__dirname, "..", "..", ".env") });
+loadEnv({ path: resolve(__dirname, "..", ".env") });
 loadEnv({ path: resolve(process.cwd(), ".env") });
 function parseAllowedUserIds(value) {
   if (!value || value.trim() === "") {
@@ -161,23 +166,14 @@ async function handleSessionStatus(event, context) {
   const statusType = event?.properties?.status?.type;
   if (statusType) {
     if (statusType === "idle") {
-      console.log(`[TelegramRemote] Session is idle. Sending finished notification.`);
       try {
         const sessionId = event?.properties?.info?.id ?? event?.properties?.sessionID ?? event?.properties?.id;
-        console.log("[TelegramRemote] Extracted sessionId for idle event:", sessionId);
-        console.log("[TelegramRemote] Event structure:", JSON.stringify(event?.properties, null, 2));
         let message = "Agent has finished.";
         if (sessionId && context.sessionTitleService) {
           const title = context.sessionTitleService.getSessionTitle(sessionId);
-          console.log("[TelegramRemote] Retrieved title from service:", title);
           if (title) {
             message = `Agent has finished: ${title}`;
           }
-        } else {
-          console.log("[TelegramRemote] SessionId or sessionTitleService missing:", {
-            hasSessionId: !!sessionId,
-            hasService: !!context.sessionTitleService
-          });
         }
         await context.bot.sendMessage(message);
       } catch (error) {
@@ -200,7 +196,6 @@ async function handleSessionUpdated(event, context) {
 
 // src/events/question-asked.ts
 async function handleQuestionAsked(event, context) {
-  console.log("[TelegramRemote] handleQuestionAsked called with event:", JSON.stringify(event, null, 2));
   const sessionID = event?.properties?.sessionID;
   const questions = event?.properties?.questions;
   if (sessionID && questions && Array.isArray(questions) && questions.length > 0 && context.bot) {
@@ -214,7 +209,6 @@ async function handleQuestionAsked(event, context) {
 
 \u2753 Questions:
 ${questionTexts}`;
-    console.log(`[TelegramRemote] Sending questions for session ${sessionID}`);
     try {
       await context.bot.sendMessage(message);
     } catch (error) {

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -1,6 +1,12 @@
-import { resolve } from "node:path";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { config as loadEnv } from "dotenv";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+loadEnv({ path: resolve(__dirname, "..", "..", ".env") });
+loadEnv({ path: resolve(__dirname, "..", ".env") });
 loadEnv({ path: resolve(process.cwd(), ".env") });
 
 export const SERVICE_NAME = "TelegramRemote";


### PR DESCRIPTION
## Problem
The plugin only loaded `.env` from `process.cwd()`, which fails when OpenCode runs from a different directory than where the plugin is installed.

## Solution
Changed `config.ts` to:
1. Import `__filename` and `__dirname` using `fileURLToPath`
2. Load `.env` from the plugin's parent directory first (`../../.env`)
3. Then from plugin directory (`../.env`)
4. Finally fall back to `process.cwd()`

This ensures the plugin finds its configuration regardless of where OpenCode is launched from.

## Testing
Tested with OpenCode running from `/root` while the plugin is installed at `/root/opencoder-telegram-plugin/`. Plugin now correctly loads the `.env` file and the Telegram bot starts successfully.

## Files Changed
- `plugin/src/config.ts` - Updated .env loading logic
- `plugin/dist/telegram-remote.js` - Rebuilt
- `.opencode/plugin/telegram-remote.js` - Copied to opencode plugin dir


resolves issue #14 